### PR TITLE
bugfix: pin @rollup/plugin-typescript to ~12.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-terser": "^1.0.0",
-        "@rollup/plugin-typescript": "^12.1.4",
+        "@rollup/plugin-typescript": "~12.1.4",
         "@types/json-schema": "^7.0.15",
         "@types/luxon": "^3.7.1",
         "@types/node": "^25.3.5",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
-      "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
+      "version": "12.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.1.4.tgz",
+      "integrity": "sha512-s5Hx+EtN60LMlDBvl5f04bEiFZmAepk27Q+mr85L/00zPDn1jtzlTV6FWn81MaIwqfWzKxmOJrBWHU6vtQyedQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-terser": "^1.0.0",
-    "@rollup/plugin-typescript": "^12.1.4",
+    "@rollup/plugin-typescript": "~12.1.4",
     "@types/json-schema": "^7.0.15",
     "@types/luxon": "^3.7.1",
     "@types/node": "^25.3.5",


### PR DESCRIPTION
## Problem

PR #5 used \^12.1.4\ which still allows 12.3.0 (semver minor). The breaking \outDir\ validation in 12.3.0 persists if npm doesn't downgrade from the existing lockfile entry.

## Fix

Changed to \~12.1.4\ (tilde = patch-only, restricts to 12.1.x).

After merging, run \m -rf node_modules && npm install\ to ensure 12.1.4 is installed.

## Verification

tsc ✅ tests (165/165) ✅ lint (0 errors) ✅ build ✅ knip ✅ audit (0 vulns) ✅