### PR TITLE
chore: move changelog generation to after:bump hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,12 +123,9 @@
         "npm run test"
       ],
       "after:bump": [
-        "npm run build"
-      ],
-      "before:npm:release": [
         "npx auto-changelog -p",
         "npm run docs",
-        "git add -A"
+        "git add CHANGELOG.md"
       ],
       "after:release": [
         "git switch -c release/${version}",


### PR DESCRIPTION
Move auto-changelog generation from before:npm:release to after:bump so the updated CHANGELOG.md is included in the release commit and tag. Also narrows git add -A to git add CHANGELOG.md to avoid staging unrelated files.